### PR TITLE
Remove f-e-d-c for pango

### DIFF
--- a/org.fontforge.FontForge.yaml
+++ b/org.fontforge.FontForge.yaml
@@ -30,12 +30,6 @@ modules:
       - type: archive
         url: https://download.gnome.org/sources/pango/1.54/pango-1.54.0.tar.xz
         sha256: 8a9eed75021ee734d7fc0fdf3a65c3bba51dfefe4ae51a9b414a60c70b2d1ed8
-        x-checker-data:
-          type: gnome
-          name: pango
-          stable-only: true
-          versions:
-            <: '1.90'
 
   - name: libspiro
     sources:


### PR DESCRIPTION
We shouldn't automatically update pango. We need to keep it in sync with the runtime.

Close #39
Close #40 
Close #41 
Close #42 
Close #43 